### PR TITLE
corrected the wrongly named variable

### DIFF
--- a/src/10-reentrancy.sol
+++ b/src/10-reentrancy.sol
@@ -6,10 +6,10 @@ interface IReentrancy {
 }
 
 contract Hack {
-    IReentrance private immutable target;
+    IReentrancy private immutable target;
 
     constructor(address _target) {
-        target = IReentrance(_target);
+        target = IReentrancy(_target);
     }
 
     // NOTE: attack cannot be called inside constructor


### PR DESCRIPTION
The variable `IReentrancy` was wrongly named `IReentrance` because of which the contract didn't compile.